### PR TITLE
Support KNX event 'GroupValue_Read'

### DIFF
--- a/knxEasy-config.js
+++ b/knxEasy-config.js
@@ -95,17 +95,23 @@ module.exports = function (RED) {
                 }
             })
             node.knxConnection.on("event", function (evt, src, dest, value) {
-                if (evt == "GroupValue_Read" || evt == "GroupValue_Write" || evt == "GroupValue_Response") {
+                if (evt == "GroupValue_Write" || evt == "GroupValue_Response" || evt == "GroupValue_Read") {
                     for (var id in node.inputUsers) {
                         if (node.inputUsers.hasOwnProperty(id)) {
                             var input = node.inputUsers[id]
                             if (input.topic == dest) {
-                                if(evt == "GroupValue_Read") {
-                                    // In case of GroupValue_Read event no payload / value is available
-                                    value = null
+                                if (evt == "GroupValue_Read") {
+                                    // Notify only in case option 'Notify read requests' is enabled
+                                    if (input.notifyreadrequest) {
+                                        // In case of GroupValue_Read event no payload / value is available
+                                        value = null
+                                        var msg = buildInputMessage(src, dest, evt, value, input.dpt)
+                                        input.send(msg)
+                                    }
+                                } else {
+                                    var msg = buildInputMessage(src, dest, evt, value, input.dpt)
+                                    input.send(msg)
                                 }
-                                var msg = buildInputMessage(src, dest, evt, value, input.dpt)
-                                input.send(msg)
                             }
                         }
                     }

--- a/knxEasy-in.html
+++ b/knxEasy-in.html
@@ -7,6 +7,7 @@
             topic: { value: "" },
             dpt: { value: "" },
             initialread: { value: false },
+            notifyreadrequest: { value: false },
             name: { value: "" }
         },
         inputs: 1,
@@ -226,42 +227,53 @@
         <label style="width:auto" for="node-input-initialread"> Read this value on startup </label>
         <input type="checkbox" id="node-input-initialread" style="display:inline-block; width:auto; vertical-align:top;">
     </div>
+    <div class="form-row">
+        <label style="width:auto" for="node-input-notifyreadrequest"> Notify read requests </label>
+        <input type="checkbox" id="node-input-notifyreadrequest" style="display:inline-block; width:auto; vertical-align:top;">
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="knxEasy-in">
     <p>	A notification message will be created anytime one of the following events occured for the selected group address:
         <ul>
             <li> a write request is received </li>
-            <li> a read request received </li>
             <li> a response to a read request is received </li>
         </ul>
     </p>
     <p> Creation of a manual read request is also possible by injecting messages to this node. <p>
+    <p> To handle read requests from external devices the option <strong>Notify read requests</strong> can be enabled.
+        Be aware that messages with a payload value <code>null</code> will be notified in this case.
+        A `switch` node or a custom function can be used to filter these messages if required.
+        Filter criteria: <code>msg.payload is null</code> or <code>msg.knx.event == "GroupValue_Read"</code>.
+    </p>
 
     <h3>Properties</h3>
         <dl class="message-properties">
             <dt>Gateway</dt>
             <dd> Selected KNX gateway. </dd>
-        </dl>
-        <dl class="message-properties">
+
             <dt>Group Address
                 <span class="property-type">x/y/z</span>
             </dt>
             <dd> KNX Group address to read/subscribe to. </dd>
-        </dl>
-        <dl class="message-properties">
+
             <dt>Datapoint</dt>
             <dd> KNX datapoint type (DPT). </dd>
-        </dl>
-        <dl class="message-properties">
-                <dt>Read on startup</dt>
-                <dd> When checked, a readRequest will be sent when connection is established/reestablished </dd>
+
+            <dt>Read on startup</dt>
+            <dd> When checked, a readRequest will be sent when connection is established/reestablished </dd>
+
+            <dt>Notify read requests</dt>
+            <dd>
+                When checked, received readRequests will be notified with an additional message.
+                <strong>Attention:</strong> Messages for received readRequests have a <code>msg.payload</code> and
+                <code>msg.knx.rawValue</code> with value <code>null</code>.
+            </dd>
         </dl>
 
-        <h3>Output</h3>
-        <ol class="node-ports">
+    <h3>Output</h3>
+        <ul>
             <li>Output of write requests
-                    <dl class="message-properties">
 <pre>
 msg = {
     "topic": "1/1/1",
@@ -279,30 +291,8 @@ msg = {
     "rawValue": [0]
     }
 } </pre>
-                    </dl>
-            </li>
-            <li>Output of read requests
-                    <dl class="message-properties">
-<pre> msg = {
-    "topic": "1/1/1",
-    "payload": null,
-    "knx": {
-        "event": "GroupValue_Read",
-        "dpt":"1.001",
-        "dptDetails": {
-            "name": "DPT_Switch",
-            "desc": "switch",
-            "use": "G"
-        },
-    "source": "2.2.2",
-    "destination": "1/1/1",
-    "rawValue": null
-    }
-} </pre>
-                    </dl>
             </li>
             <li>Output of responses
-                    <dl class="message-properties">
 <pre> msg = {
     "topic": "1/1/1",
     "payload": 0,
@@ -319,7 +309,24 @@ msg = {
     "rawValue": [0]
     }
 } </pre>
-                    </dl>
             </li>
-        </ol>
+            <li>Output of read requests (only available if option `Notify read requests` is enabled)
+<pre> msg = {
+    "topic": "1/1/1",
+    "payload": null,
+    "knx": {
+        "event": "GroupValue_Read",
+        "dpt":"1.001",
+        "dptDetails": {
+            "name": "DPT_Switch",
+            "desc": "switch",
+            "use": "G"
+        },
+    "source": "2.2.2",
+    "destination": "1/1/1",
+    "rawValue": null
+    }
+} </pre>
+            </li>
+        </ul>
     </script>

--- a/knxEasy-in.html
+++ b/knxEasy-in.html
@@ -229,8 +229,14 @@
 </script>
 
 <script type="text/x-red" data-help-name="knxEasy-in">
-    <p>	Anytime the selected group address is written to, you will be notified. </p>
-    <p> Manual readRequests is also possible by injecting messages to this node <p>
+    <p>	A notification message will be created anytime one of the following events occured for the selected group address:
+        <ul>
+            <li> a write request is received </li>
+            <li> a read request received </li>
+            <li> a response to a read request is received </li>
+        </ul>
+    </p>
+    <p> Creation of a manual read request is also possible by injecting messages to this node. <p>
 
     <h3>Properties</h3>
         <dl class="message-properties">
@@ -253,22 +259,67 @@
         </dl>
 
         <h3>Output</h3>
-        <pre> 
+        <ol class="node-ports">
+            <li>Output of write requests
+                    <dl class="message-properties">
+<pre>
 msg = {
     "topic": "1/1/1",
-    "payload": 0, 
-    "knx": { 
-        "event": "GroupValue_Write", 
-        "dpt":"1.001", 
-        "dptDetails": { 
+    "payload": 0,
+    "knx": {
+        "event": "GroupValue_Write",
+        "dpt": "1.001",
+        "dptDetails": {
             "name": "DPT_Switch",
             "desc": "switch",
-            "use":"G"
-        }, 
-    "source":"2.2.2", 
-    "destination": "1/1/1", 
-    "rawValue":[0]
+            "use": "G"
+        },
+    "source": "2.2.2",
+    "destination": "1/1/1",
+    "rawValue": [0]
     }
 } </pre>
-        
+                    </dl>
+            </li>
+            <li>Output of read requests
+                    <dl class="message-properties">
+<pre> msg = {
+    "topic": "1/1/1",
+    "payload": null,
+    "knx": {
+        "event": "GroupValue_Read",
+        "dpt":"1.001",
+        "dptDetails": {
+            "name": "DPT_Switch",
+            "desc": "switch",
+            "use": "G"
+        },
+    "source": "2.2.2",
+    "destination": "1/1/1",
+    "rawValue": null
+    }
+} </pre>
+                    </dl>
+            </li>
+            <li>Output of responses
+                    <dl class="message-properties">
+<pre> msg = {
+    "topic": "1/1/1",
+    "payload": 0,
+    "knx": {
+        "event": "GroupValue_Response",
+        "dpt":"1.001",
+        "dptDetails": {
+            "name": "DPT_Switch",
+            "desc": "switch",
+            "use": "G"
+        },
+    "source": "2.2.2",
+    "destination": "1/1/1",
+    "rawValue": [0]
+    }
+} </pre>
+                    </dl>
+            </li>
+        </ol>
     </script>

--- a/knxEasy-in.js
+++ b/knxEasy-in.js
@@ -6,6 +6,7 @@ module.exports = function (RED) {
         node.topic = config.topic
         node.dpt = config.dpt || "1.001"
         node.initialread = config.initialread || false
+        node.notifyreadrequest = config.notifyreadrequest || false
 
         if (node.server) {
             if (node.topic) {


### PR DESCRIPTION
Support the KNX event type 'GroupValue_Read'.

This is used by devices to trigger update of values (e.g. date and time).
Tested with MDT BE-GT2TW.01 time communication object requested on device startup.

Please let me know if you have any improvements to the code I can implement.