### PR TITLE
Corrected DPT naming with trailing zeros for knxEasy-in node

### DIFF
--- a/knxEasy-in.html
+++ b/knxEasy-in.html
@@ -30,7 +30,7 @@
     <div class="form-row">
         <label for="node-input-dpt"><i class="fa fa-tasks"></i> Datapoint </label>
         <select id="node-input-dpt">
-		    <option value="1.001">1.001 -- DPT_Switch</option>
+            <option value="1.001">1.001 -- DPT_Switch</option>
             <option value="1.002">1.002 -- DPT_Bool</option>
             <option value="1.003">1.003 -- DPT_Enable</option>
             <option value="1.004">1.004 -- DPT_Ramp</option>
@@ -39,7 +39,7 @@
             <option value="1.007">1.007 -- DPT_Step</option>
             <option value="1.008">1.008 -- DPT_UpDown</option>
             <option value="1.009">1.009 -- DPT_OpenClose</option>
-            <option value="1.01">1.01 -- DPT_Start</option>
+            <option value="1.010">1.010 -- DPT_Start</option>
             <option value="1.011">1.011 -- DPT_State</option>
             <option value="1.012">1.012 -- DPT_Invert</option>
             <option value="1.013">1.013 -- DPT_DimSendStyle</option>
@@ -52,7 +52,7 @@
             <option value="1.021">1.021 -- DPT_LogicalFunction</option>
             <option value="1.022">1.022 -- DPT_Scene_AB</option>
             <option value="1.023">1.023 -- DPT_ShutterBlinds_Mode</option>
-            <option value="1.1">1.1 -- DPT_Heat/Cool</option>
+            <option value="1.100">1.100 -- DPT_Heat/Cool</option>
             <option value="2.001">2.001 -- DPT_Switch_Control</option>
             <option value="2.002">2.002 -- DPT_Bool_Control</option>
             <option value="2.003">2.003 -- DPT_Enable_Control</option>
@@ -62,7 +62,7 @@
             <option value="2.007">2.007 -- DPT_Step_Control</option>
             <option value="2.008">2.008 -- DPT_Direction1_Control</option>
             <option value="2.009">2.009 -- DPT_Direction2_Control</option>
-            <option value="2.01">2.01 -- DPT_Start_Control</option>
+            <option value="2.010">2.010 -- DPT_Start_Control</option>
             <option value="2.011">2.011 -- DPT_State_Control</option>
             <option value="2.012">2.012 -- DPT_Invert_Control</option>
             <option value="3.007">3.007 -- DPT_Control_Dimming</option>
@@ -74,10 +74,10 @@
             <option value="5.004">5.004 -- DPT_Percent_U8</option>
             <option value="5.005">5.005 -- DPT_DecimalFactor</option>
             <option value="5.006">5.006 -- DPT_Tariff</option>
-            <option value="5.01">5.01 -- DPT_Value_1_Ucount</option>
+            <option value="5.010">5.010 -- DPT_Value_1_Ucount</option>
             <option value="6.001">6.001 -- DPT_Percent_V8</option>
-            <option value="6.01">6.01 -- DPT_Value_1_Count</option>
-            <option value="6.02">6.02 -- DPT_Status_Mode3</option>
+            <option value="6.010">6.010 -- DPT_Value_1_Count</option>
+            <option value="6.020">6.020 -- DPT_Status_Mode3</option>
             <option value="7.001">7.001 -- DPT_Value_2_Ucount</option>
             <option value="7.002">7.002 -- DPT_TimePeriodMsec</option>
             <option value="7.003">7.003 -- DPT_TimePeriod10MSec</option>
@@ -85,7 +85,7 @@
             <option value="7.005">7.005 -- DPT_TimePeriodSec</option>
             <option value="7.006">7.006 -- DPT_TimePeriodMin</option>
             <option value="7.007">7.007 -- DPT_TimePeriodHrs</option>
-            <option value="7.01">7.01 -- DPT_PropDataType</option>
+            <option value="7.010">7.010 -- DPT_PropDataType</option>
             <option value="7.011">7.011 -- DPT_Length_mm</option>
             <option value="7.012">7.012 -- DPT_UElCurrentmA</option>
             <option value="7.013">7.013 -- DPT_Brightness</option>
@@ -106,9 +106,9 @@
             <option value="9.006">9.006 -- DPT_Value_Pres</option>
             <option value="9.007">9.007 -- DPT_Value_Humidity</option>
             <option value="9.008">9.008 -- DPT_Value_AirQuality</option>
-            <option value="9.01">9.01 -- DPT_Value_Time1</option>
+            <option value="9.010">9.010 -- DPT_Value_Time1</option>
             <option value="9.011">9.011 -- DPT_Value_Time2</option>
-            <option value="9.02">9.02 -- DPT_Value_Volt</option>
+            <option value="9.020">9.020 -- DPT_Value_Volt</option>
             <option value="9.021">9.021 -- DPT_Value_Curr</option>
             <option value="9.022">9.022 -- DPT_PowerDensity</option>
             <option value="9.023">9.023 -- DPT_KelvinPerPercent</option>
@@ -122,14 +122,14 @@
             <option value="12.001">12.001 -- DPT_Value_4_Ucount</option>
             <option value="13.001">13.001 -- DPT_Value_4_Count</option>
             <option value="13.002">13.002 -- DPT_FlowRate_m3/h</option>
-            <option value="13.01">13.01 -- DPT_ActiveEnergy</option>
+            <option value="13.010">13.010 -- DPT_ActiveEnergy</option>
             <option value="13.011">13.011 -- DPT_ApparantEnergy</option>
             <option value="13.012">13.012 -- DPT_ReactiveEnergy</option>
             <option value="13.013">13.013 -- DPT_ActiveEnergy_kWh</option>
             <option value="13.014">13.014 -- DPT_ApparantEnergy_kVAh</option>
             <option value="13.015">13.015 -- DPT_ReactiveEnergy_kVARh</option>
-            <option value="13.1">13.1 -- DPT_LongDeltaTimeSec</option>
-            <option value="14">14 -- DPT_Value_Acceleration</option>
+            <option value="13.100">13.100 -- DPT_LongDeltaTimeSec</option>
+            <option value="14.000">14.000 -- DPT_Value_Acceleration</option>
             <option value="14.001">14.001 -- DPT_Value_Acceleration_Angular</option>
             <option value="14.002">14.002 -- DPT_Value_Activation_Energy</option>
             <option value="14.003">14.003 -- DPT_Value_Activity</option>
@@ -139,7 +139,7 @@
             <option value="14.007">14.007 -- DPT_Value_AngleDeg</option>
             <option value="14.008">14.008 -- DPT_Value_Angular_Momentum</option>
             <option value="14.009">14.009 -- DPT_Value_Angular_Velocity</option>
-            <option value="14.01">14.01 -- DPT_Value_Area</option>
+            <option value="14.010">14.010 -- DPT_Value_Area</option>
             <option value="14.011">14.011 -- DPT_Value_Capacitance</option>
             <option value="14.012">14.012 -- DPT_Value_Charge_DensitySurface</option>
             <option value="14.013">14.013 -- DPT_Value_Charge_DensityVolume</option>
@@ -149,7 +149,7 @@
             <option value="14.017">14.017 -- DPT_Value_Density</option>
             <option value="14.018">14.018 -- DPT_Value_Electric_Charge</option>
             <option value="14.019">14.019 -- DPT_Value_Electric_Current</option>
-            <option value="14.02">14.02 -- DPT_Value_Electric_CurrentDensity</option>
+            <option value="14.020">14.020 -- DPT_Value_Electric_CurrentDensity</option>
             <option value="14.021">14.021 -- DPT_Value_Electric_DipoleMoment</option>
             <option value="14.022">14.022 -- DPT_Value_Electric_Displacement</option>
             <option value="14.023">14.023 -- DPT_Value_Electric_FieldStrength</option>
@@ -159,7 +159,7 @@
             <option value="14.027">14.027 -- DPT_Value_Electric_Potential</option>
             <option value="14.028">14.028 -- DPT_Value_Electric_PotentialDifference</option>
             <option value="14.029">14.029 -- DPT_Value_ElectromagneticMoment</option>
-            <option value="14.03">14.03 -- DPT_Value_Electromotive_Force</option>
+            <option value="14.030">14.030 -- DPT_Value_Electromotive_Force</option>
             <option value="14.031">14.031 -- DPT_Value_Energy</option>
             <option value="14.032">14.032 -- DPT_Value_Force</option>
             <option value="14.033">14.033 -- DPT_Value_Frequency</option>
@@ -169,7 +169,7 @@
             <option value="14.037">14.037 -- DPT_Value_Heat_Quantity</option>
             <option value="14.038">14.038 -- DPT_Value_Impedance</option>
             <option value="14.039">14.039 -- DPT_Value_Length</option>
-            <option value="14.04">14.04 -- DPT_Value_Light_Quantity</option>
+            <option value="14.040">14.040 -- DPT_Value_Light_Quantity</option>
             <option value="14.041">14.041 -- DPT_Value_Luminance</option>
             <option value="14.042">14.042 -- DPT_Value_Luminous_Flux</option>
             <option value="14.043">14.043 -- DPT_Value_Luminous_Intensity</option>
@@ -179,7 +179,7 @@
             <option value="14.047">14.047 -- DPT_Value_Magnetic_Moment</option>
             <option value="14.048">14.048 -- DPT_Value_Magnetic_Polarization</option>
             <option value="14.049">14.049 -- DPT_Value_Magnetization</option>
-            <option value="14.05">14.05 -- DPT_Value_MagnetomotiveForce</option>
+            <option value="14.050">14.050 -- DPT_Value_MagnetomotiveForce</option>
             <option value="14.051">14.051 -- DPT_Value_Mass</option>
             <option value="14.052">14.052 -- DPT_Value_MassFlux</option>
             <option value="14.053">14.053 -- DPT_Value_Momentum</option>
@@ -189,7 +189,7 @@
             <option value="14.057">14.057 -- DPT_Value_Power_Factor</option>
             <option value="14.058">14.058 -- DPT_Value_Pressure</option>
             <option value="14.059">14.059 -- DPT_Value_Reactance</option>
-            <option value="14.06">14.06 -- DPT_Value_Resistance</option>
+            <option value="14.060">14.060 -- DPT_Value_Resistance</option>
             <option value="14.061">14.061 -- DPT_Value_Resistivity</option>
             <option value="14.062">14.062 -- DPT_Value_SelfInductance</option>
             <option value="14.063">14.063 -- DPT_Value_SolidAngle</option>
@@ -199,7 +199,7 @@
             <option value="14.067">14.067 -- DPT_Value_Surface_Tension</option>
             <option value="14.068">14.068 -- DPT_Value_Common_Temperature</option>
             <option value="14.069">14.069 -- DPT_Value_Absolute_Temperature</option>
-            <option value="14.07">14.07 -- DPT_Value_TemperatureDifference</option>
+            <option value="14.070">14.070 -- DPT_Value_TemperatureDifference</option>
             <option value="14.071">14.071 -- DPT_Value_Thermal_Capacity</option>
             <option value="14.072">14.072 -- DPT_Value_Thermal_Conductivity</option>
             <option value="14.073">14.073 -- DPT_Value_ThermoelectricPower</option>
@@ -209,13 +209,13 @@
             <option value="14.077">14.077 -- DPT_Value_Volume_Flux</option>
             <option value="14.078">14.078 -- DPT_Value_Weight</option>
             <option value="14.079">14.079 -- DPT_Value_Work</option>
-            <option value="15">15 -- DPT_Access_Data</option>
-            <option value="16">16 -- DPT_String_ASCII</option>
+            <option value="15.000">15.000 -- DPT_Access_Data</option>
+            <option value="16.000">16.000 -- DPT_String_ASCII</option>
             <option value="16.001">16.001 -- DPT_String_8859_1</option>
             <option value="17.001">17.001 -- DPT_SceneNumber</option>
             <option value="18.001">18.001 -- DPT_SceneControl</option>
             <option value="19.001">19.001 -- DPT_DateTime</option>
-	</select>
+        </select>
     </div>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name </label>
@@ -224,7 +224,7 @@
 </script>
 
 <script type="text/x-red" data-help-name="knxEasy-in">
-    <p> Select KNX server/gateway, select what Group address to listen to + the DPT. </p> 
+    <p> Select KNX server/gateway, select what Group address to listen to + the DPT. </p>
     <p>	Anytime this group address is written to, you will be notified. </p>
     <p> msg : { topic : "Destination", payload: "Value", knx: "knx, explained below" </p>
     <p>	knx: { event: "GroupValue_write", dpt: "f.eks. DPT14.019", dptDetails: "name, description,unit,use", source, destination }</p>


### PR DESCRIPTION
Same improvement as provided by @moccacup in pullrequest #5.