### PR TITLE
Initial read on implement

### DIFF
--- a/knxEasy-config.js
+++ b/knxEasy-config.js
@@ -54,6 +54,7 @@ module.exports = (RED) => {
         var node = this
         node.host = n.host
         node.port = n.port
+        node.status = "disconnected";
         node.context().global.set("knxEasyDpts", dptlib.dpts)
 
         var knxErrorTimeout
@@ -64,6 +65,11 @@ module.exports = (RED) => {
             userType == "in"
                 ? node.inputUsers.push(knxNode)
                 : node.outputUsers.push(knxNode)
+
+            if (node.status === "connected" && knxNode.initialread) {
+                knxNode._events.input();
+            }
+
             if (node.inputUsers.length + node.outputUsers.length === 1) {
                 node.connect();
             }
@@ -100,6 +106,7 @@ module.exports = (RED) => {
         }
 
         node.setStatus = (status) => {
+            node.status = status;
             switch (status) {
                 case "connected":
                     node.setStatusHelper("green", "node-red:common.status.connected")

--- a/knxEasy-config.js
+++ b/knxEasy-config.js
@@ -67,7 +67,7 @@ module.exports = (RED) => {
                 : node.outputUsers.push(knxNode)
 
             if (node.status === "connected" && knxNode.initialread) {
-                knxNode._events.input();
+                node.readValue(knxNode.topic);
             }
 
             if (node.inputUsers.length + node.outputUsers.length === 1) {
@@ -91,10 +91,16 @@ module.exports = (RED) => {
                 .filter(input => input.initialread)
                 .forEach(input => {
                     if (readHistory.includes(input.topic)) return
-                    setTimeout(input._events.input, delay)
+                    setTimeout(() => node.readValue(input.topic), delay)
                     delay = delay + 50
                     readHistory.push(input.topic)
                 })
+        }
+
+        node.readValue = topic => {
+            if (node.knxConnection) {
+                node.knxConnection.read(topic)
+            }
         }
 
         node.setStatusHelper = (fill, text) => {

--- a/knxEasy-in.js
+++ b/knxEasy-in.js
@@ -11,8 +11,8 @@ module.exports = function (RED) {
         node.initialread = config.initialread || false
 
         node.on("input", function (msg) {
-            if (node.server && node.server.knxConnection && node.topic) {
-                node.server.knxConnection.read(node.topic)
+            if (node.server && node.topic) {
+                node.server.readValue(node.topic)
             }
         })
 

--- a/knxEasy-in.js
+++ b/knxEasy-in.js
@@ -10,21 +10,23 @@ module.exports = function (RED) {
         node.notifywrite = config.notifywrite
         node.initialread = config.initialread || false
 
-        if (node.server) {
-            if (node.topic) {
-                node.server.register("in", node)
-            }
-        }
         node.on("input", function (msg) {
             if (node.server && node.server.knxConnection && node.topic) {
                 node.server.knxConnection.read(node.topic)
             }
         })
+
         node.on('close', function () {
             if (node.server) {
-                node.server.deregister("in", node);
+                node.server.deregister("in", node)
             }
-        });
+        })
+
+        if (node.server) {
+            if (node.topic) {
+                node.server.register("in", node)
+            }
+        }
     }
     RED.nodes.registerType("knxEasy-in", knxEasyIn)
 }


### PR DESCRIPTION
This PR allows nodes to read their initial value when a knx connection is already established. This is mostly the case when you implement a new flow or flow changes and other flows are already using a knx connection. 