### PR TITLE
ETS csv file + node's status

### DIFF
--- a/knxEasy-config.html
+++ b/knxEasy-config.html
@@ -2,8 +2,9 @@
     RED.nodes.registerType('knxEasy-config',{
         category: 'config',
         defaults: {
-            host: {value:"localhost",required:true},
+            host: {value:"224.0.23.12",required:true},
             port: {value:3671,required:true,validate:RED.validators.number()},
+            csv: {value:"",required:false},
         },
         label: function() {
             return this.host+":"+this.port;
@@ -20,4 +21,14 @@
         <label for="node-config-input-port"><i class="icon-bookmark"></i> Port</label>
         <input type="text" id="node-config-input-port">
     </div>
+    <div class="form-row">
+        <label for="node-config-input-csv"><i class="icon-bookmark"></i> ETS Group Addresses list</label>
+        <br /><i>On ETS, click the group addresses list, then right click, then select 'export group addresses'. On the export window, select these options -> Output Format: CSV, CSV Format: 1/1 Name/Address, Export with header line: checked, CSV Separator: Tabulator. </i>
+ 
+        <textarea rows=20 id="node-config-input-csv" style="width:100%" placeholder="Paste here your CSV exported file from ETS">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="knxEasy-config">
+<p><b>ETS Group Addresses list</b>: Optionally, you can paste here the CSV file from ETS. This CSV will then be used by the KnxEasy-in node (if you select "Listen to all Group Addresses" on the KnxEasy-in node) to automatically decode all the raw values received from the KNX bus. These values will then be outputted by the msg.payload</p>
 </script>

--- a/knxEasy-config.html
+++ b/knxEasy-config.html
@@ -6,10 +6,31 @@
             port: {value:3671,required:true,validate:RED.validators.number()},
             csv: {value:"",required:false},
         },
+        oneditsave: function() {
+            // Check if the csv file contains errors
+            if($("#node-config-input-csv").val() != 'undefined' && $("#node-config-input-csv").val()!=""){
+                var checkResult="Upon deploy, i'll parse the CSV. Please see the debug TAB or node-red's log for errors/warnings"
+                var myNotification= RED.notify(checkResult,
+                {
+                    modal: true,
+                    fixed: true,
+                    type: 'warning',
+                    buttons: [
+                        {
+                            text: "OK",
+                            click: function(e) {
+                                myNotification.close();
+                            }
+                        }]
+                })
+            }
+        },
         label: function() {
             return this.host+":"+this.port;
         }
     });
+
+    
 </script>
 
 <script type="text/x-red" data-template-name="knxEasy-config">

--- a/knxEasy-config.js
+++ b/knxEasy-config.js
@@ -36,6 +36,53 @@ toConcattedSubtypes = (acc, baseType) => {
     return acc.concat(subtypes)
 }
 
+readCSV = (_csv,RED) => {
+    if (_csv=="") {
+        RED.log.info('KnxEasy: no csv ETS found')
+    }else{RED.log.info('KnxEasy: csv ETS found !')}
+    // Read and decode the CSV in an Array containing:  "group address", "DPT", "Device Name"
+    let fileGA = _csv.split("\n");
+     // Controllo se le righe dei gruppi contengono il separatore di tabulazione
+    if (fileGA[0].search("\t")==-1) {
+        RED.log.error('KnxEasy: ERROR: the csv ETS file must have the tabulation as separator')
+        return null;
+    }   
+    var ajsonOutput=new Array(); // Array: qui va l'output totale con i nodi per node-red
+    for (let index = 0; index < fileGA.length; index++) {
+        const element = fileGA[index].replace(/\"/g,""); // Rimuovo le virgolette
+        
+        if (element !== "") {
+            if (element.split("\t")[1].search("-")==-1 && element.split("\t")[1].search("/")!==-1) {
+                // Ho trovato una riga contenente un GA valido, cioè con 2 "/"
+                if (element.split("\t")[5] == "") {
+                    RED.log.error("KnxEasy: ERROR: Datapoint not set in ETS CSV. Please set the datapoint with ETS and export the group addresses again. ->" + element.split("\t")[0] + " " + element.split("\t")[1])
+                    return null;
+                }
+                var DPTa = element.split("\t")[5].split("-")[1];
+                var DPTb = "";
+                try {
+                     DPTb = element.split("\t")[5].split("-")[2];
+                } catch (error) {
+                    DPTb = "001"; // default
+                }
+                if (!DPTb) {
+                    RED.log.warn("KnxEasy: WARNING: Datapoint not fully set (there is only the first part on the left of the '.'). I applied a default .001, but please set the datapoint with ETS and export the group addresses again. ->" + element.split("\t")[0] + " " + element.split("\t")[1] + " Datapoint: " + element.split("\t")[5]);
+                    DPTb = "001"; // default
+                } 
+                // Trailing zeroes
+                if (DPTb.length == 1) {
+                    DPTb = "00" + DPTb;
+                }else if (DPTb.length==2) {
+                    DPTb = "0" + DPTb;
+                }if (DPTb.length==3) {
+                    DPTb = "" + DPTb; // stupid, but for readability
+                }
+                ajsonOutput.push({ga:element.split("\t")[1],dpt:DPTa+"."+DPTb,devicename:element.split("\t")[0]});
+            }
+        }
+    }
+    return ajsonOutput;
+}
 
 module.exports = (RED) => {
     RED.httpAdmin.get("/knxEasyDpts", RED.auth.needsPermission('knxEasy-config.read'), function (req, res) {
@@ -54,7 +101,11 @@ module.exports = (RED) => {
         var node = this
         node.host = n.host
         node.port = n.port
-        node.status = "disconnected";
+        node.csv = readCSV(n.csv,RED,node) // Array from ETS CSV Group Addresses
+        // for (let index = 0; index < node.csv.length; index++) {
+        //     RED.log.info("KnxEasy: CSV " + node.csv[index].device)
+        // }
+        node.status = "disconnected"
 
         var knxErrorTimeout
         node.inputUsers = []
@@ -89,10 +140,21 @@ module.exports = (RED) => {
             node.inputUsers
                 .filter(input => input.initialread)
                 .forEach(input => {
-                    if (readHistory.includes(input.topic)) return
-                    setTimeout(() => node.readValue(input.topic), delay)
-                    delay = delay + 50
-                    readHistory.push(input.topic)
+                    if (input.listenallga) {
+                        delay = delay + 50
+                        for (let index = 0; index < node.csv.length; index++) {
+                            const element = node.csv[index];
+                            if (readHistory.includes(element.ga)) return
+                            setTimeout(() => node.readValue(element.ga), delay)
+                            readHistory.push(element.ga)
+                        }                        
+                    } else {
+                        if (readHistory.includes(input.topic)) return
+                        setTimeout(() => node.readValue(input.topic), delay)
+                        delay = delay + 50
+                        readHistory.push(input.topic)
+                    }
+                    
                 })
         }
 
@@ -151,38 +213,89 @@ module.exports = (RED) => {
             node.knxConnection.on("event", function (evt, src, dest, rawValue) {
                 switch (evt) {
                     case "GroupValue_Write": {
+                     
                         node.inputUsers
-                            .filter(input => input.topic == dest && input.notifywrite)
+                            .filter(input => input.notifywrite)
                             .forEach(input => {
-                                let msg = buildInputMessage(src, dest, evt, rawValue, input.dpt)
-                                input.send(msg)
+                                if (input.listenallga) {
+                                    // Get the DPT
+                                    let oGA=node.csv.filter(sga => sga.ga == dest)[0]
+                                    let msg = buildInputMessage(src, dest, evt, rawValue, oGA.dpt, oGA.devicename)
+                                    input.send(msg)                                    
+                                }else if (input.topic == dest) {
+                                    let msg = buildInputMessage(src, dest, evt, rawValue, input.dpt)
+                                    input.send(msg)
+                                }
                             })
                         break;
+                        
+                        // node.inputUsers
+                        //     .filter(input => input.topic == dest && input.notifywrite)
+                        //     .forEach(input => {
+                        //         let msg = buildInputMessage(src, dest, evt, rawValue, input.dpt)
+                        //         input.send(msg)
+                        //     })
+                        //     break;
+                        
                     }
                     case "GroupValue_Response": {
+                        
                         node.inputUsers
-                            .filter(input => input.topic == dest && input.notifyresponse)
+                            .filter(input => input.notifyresponse)
                             .forEach(input => {
-                                let msg = buildInputMessage(src, dest, evt, rawValue, input.dpt)
-                                input.send(msg)
+                                if (input.listenallga) {
+                                    // Get the DPT
+                                    let oGA=node.csv.filter(sga => sga.ga == dest)[0]
+                                    let msg = buildInputMessage(src, dest, evt, rawValue, oGA.dpt, oGA.devicename)
+                                    input.send(msg)                                    
+                                }else if (input.topic == dest) {
+                                    let msg = buildInputMessage(src, dest, evt, rawValue, input.dpt)
+                                    input.send(msg)
+                                }
                             })
                         break;
+
+                            // node.inputUsers
+                            //     .filter(input => input.topic == dest && input.notifyresponse)
+                            //     .forEach(input => {
+                            //         let msg = buildInputMessage(src, dest, evt, rawValue, input.dpt)
+                            //         input.send(msg)
+                            //     })
+                            // break;
+                        
                     }
                     case "GroupValue_Read": {
+                        
                         node.inputUsers
-                            .filter(input => input.topic == dest && input.notifyreadrequest)
+                            .filter(input => input.notifyreadrequest)
                             .forEach(input => {
-                                let msg = buildInputMessage(src, dest, evt, null, input.dpt)
-                                input.send(msg)
+                                if (input.listenallga) {
+                                    // Get the DPT
+                                    let oGA=node.csv.filter(sga => sga.ga == dest)[0]
+                                    let msg = buildInputMessage(src, dest, evt, null, oGA.dpt, oGA.devicename)
+                                    input.send(msg)                                    
+                                }else if (input.topic == dest) {
+                                    let msg = buildInputMessage(src, dest, evt, null, input.dpt)
+                                    input.send(msg)
+                                }
                             })
                         break;
+
+                            // node.inputUsers
+                            //     .filter(input => input.topic == dest && input.notifyreadrequest)
+                            //     .forEach(input => {
+                            //         let msg = buildInputMessage(src, dest, evt, null, input.dpt)
+                            //         input.send(msg)
+                            //     })
+                            // break;
+                        
                     }
                     default: return
                 }
             })
         }
 
-        function buildInputMessage(src, dest, evt, value, inputDpt) {
+        function buildInputMessage(src, dest, evt, value, inputDpt, _devicename) {
             // Resolve DPT and convert value if available
             var dpt = dptlib.resolve(inputDpt)
             var jsValue = null
@@ -203,6 +316,7 @@ module.exports = (RED) => {
                     , destination: dest
                     , rawValue: value
                 }
+                , devicename: (typeof _devicename !== 'undefined') ? _devicename : ""
             }
         }
 

--- a/knxEasy-config.js
+++ b/knxEasy-config.js
@@ -123,7 +123,7 @@ module.exports = (RED) => {
         // for (let index = 0; index < node.csv.length; index++) {
         //     RED.log.info("KnxEasy: CSV " + node.csv[index].device)
         // }
-        node.status = "disconnected"
+        node.setStatusHelper("disconnected","red","")
 
         var knxErrorTimeout
         node.inputUsers = []
@@ -183,6 +183,7 @@ module.exports = (RED) => {
         }
 
         node.setStatusHelper = (_status, _color, _text) => {
+            node.status = _status
             function nextStatus(input) {
                 input.status({ fill: _color, shape: "dot", text: "("+ input.topic +") " + _status + " " + _text  })
             }
@@ -206,7 +207,7 @@ module.exports = (RED) => {
                     error: (connstatus) => {
                         node.error(connstatus)
                         if (connstatus == "E_KNX_CONNECTION") {
-                            node.setStatusHelper("KNXError","yellow","Error KNX BUS communication")
+                            node.setStatusHelper("knxError","yellow","Error KNX BUS communication")
                         } else {
                             node.setStatusHelper("disconnected","red","")
                         }
@@ -327,7 +328,7 @@ module.exports = (RED) => {
         }
 
         node.on("close", function () {
-            node.status="disconnected"
+            node.setStatusHelper("disconnected","red","")
             node.knxConnection.Disconnect()
             node.knxConnection = null
         })

--- a/knxEasy-config.js
+++ b/knxEasy-config.js
@@ -207,7 +207,7 @@ module.exports = (RED) => {
                                     // Get the DPT
                                     let oGA=node.csv.filter(sga => sga.ga == dest)[0]
                                     let msg = buildInputMessage(src, dest, evt, rawValue, oGA.dpt, oGA.devicename)
-                                    input.status({ fill: "green", shape: "dot", text: "("+ msg.knx.destination +") " + msg.payload + " dpt: " + msg.knx.dpt })
+                                    input.status({ fill: "green", shape: "dot", text: "("+ msg.knx.destination +") " + msg.payload + " dpt:" + msg.knx.dpt })
                                     input.send(msg)                                    
                                 }else if (input.topic == dest) {
                                     let msg = buildInputMessage(src, dest, evt, rawValue, input.dpt)

--- a/knxEasy-in.html
+++ b/knxEasy-in.html
@@ -10,6 +10,7 @@
             notifyreadrequest: { value: false },
             notifyresponse: { value: false },
             notifywrite: { value: true },
+            listenallga: { value: false },
             name: { value: "" }
         },
         inputs: 1,
@@ -36,7 +37,29 @@
                 $("#node-input-notifywrite").prop("checked", true)
                 $("#node-input-notifyresponse").prop("checked", true)
             }
+           
+            // Hide or show the GA and DPT fields if Notify on all Group Addresses is checked
+            if (RED.nodes.node(this.server).csv!="") {
+                $("#node-input-listenallga").prop("disabled", false);
+                $("#helpallga").hide()
+                $("#node-input-listenallga").on('change',function() {
+                    if ($("#node-input-listenallga").is(":checked")) {
+                        $("#GAandDPT").hide()
+                    }else{
+                        $("#GAandDPT").show()
+                    }
+                })
+            }else{
+                $("#node-input-listenallga").prop("disabled", true);
+                $("#node-input-listenallga").prop("checked", false)
+                $("#GAandDPT").show()
+                $("#helpallga").show()
+            }
+            
+            
         }
+
+        
     })
 </script>
 
@@ -45,13 +68,15 @@
         <label for="node-input-server"><i class="fa fa-tag"></i> Gateway </label>
         <input type="text" id="node-input-server">
     </div>
-    <div class="form-row">
-        <label for="node-input-topic"><i class="fa fa-tasks"></i> Group Address </label>
-        <input type="text" id="node-input-topic" placeholder="Group Address (1/1/1)">
-    </div>
-    <div class="form-row">
-        <label for="node-input-dpt"><i class="fa fa-tasks"></i> Datapoint </label>
-        <select id="node-input-dpt"></select>
+    <div id="GAandDPT">
+        <div class="form-row">
+            <label for="node-input-topic"><i class="fa fa-tasks"></i> Group Address </label>
+            <input type="text" id="node-input-topic" placeholder="Ex: 1/1/1 or select 'Listen to all Groups'">
+        </div>
+        <div class="form-row">
+            <label for="node-input-dpt"><i class="fa fa-tasks"></i> Datapoint </label>
+            <select id="node-input-dpt"></select>
+        </div>
     </div>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name </label>
@@ -85,6 +110,13 @@
                 <label style="width:auto" for="node-input-initialread"> Read this value once on connection/reconnect </label>
             </div>
         </dd>
+        <dd>
+            <div class="form-row">
+                <input type="checkbox" id="node-input-listenallga" style="display:inline-block; width:auto; vertical-align:top;">
+                <label style="width:auto" for="node-input-listenallga"> Listen to all Group Addresses (using ETS file)</label>
+                <div id="helpallga"><i>   You must import your ETS file, otherwise this option is disabled.<br />Please see the config node. <br />Once imported, please click deploy to enable this option</i></div>
+            </div>
+        </dd>
 </script>
 
 <script type="text/x-red" data-help-name="knxEasy-in">
@@ -97,6 +129,7 @@
         Default is to only notify write requests
     </p>
     <p> Creation of a manual read request is also possible by injecting any message to this node. <p>
+    <p> <b>Listen to all group addresses</b> checkbox, allow the node to listen to all group address it receives from the bus. In order for this option to work, the node must know each datapoints belonging to each group address, in order to output a correctly formatted payload. For this reason, you need to import your ETS file. Please see the configuration node to do so. <p>
     <p> msg.payload will contain your desired value </p>
     <p> If you have enabled notification of read requests,
         be aware that the output msg will have a payload of <code>null</code> for these events.

--- a/knxEasy-in.html
+++ b/knxEasy-in.html
@@ -39,7 +39,8 @@
             }
            
             // Hide or show the GA and DPT fields if Notify on all Group Addresses is checked
-            if (RED.nodes.node(this.server).csv!="") {
+            if(this.server){
+                if (RED.nodes.node(this.server).csv != 'undefined' && RED.nodes.node(this.server).csv!="") {
                 $("#node-input-listenallga").prop("disabled", false);
                 $("#helpallga").hide()
                 $("#node-input-listenallga").on('change',function() {
@@ -49,14 +50,18 @@
                         $("#GAandDPT").show()
                     }
                 })
+                }else{
+                    $("#node-input-listenallga").prop("disabled", true);
+                    $("#node-input-listenallga").prop("checked", false)
+                    $("#GAandDPT").show()
+                    $("#helpallga").show()
+                }
             }else{
                 $("#node-input-listenallga").prop("disabled", true);
                 $("#node-input-listenallga").prop("checked", false)
                 $("#GAandDPT").show()
                 $("#helpallga").show()
             }
-            
-            
         }
 
         

--- a/knxEasy-in.js
+++ b/knxEasy-in.js
@@ -11,6 +11,8 @@ module.exports = function (RED) {
         node.initialread = config.initialread || false
         node.listenallga = config.listenallga || false
         
+  
+        
         node.on("input", function (msg) {
             if (!node.listenallga) {
                 if (node.server && node.topic) {

--- a/knxEasy-in.js
+++ b/knxEasy-in.js
@@ -9,11 +9,22 @@ module.exports = function (RED) {
         node.notifyresponse = config.notifyresponse || false
         node.notifywrite = config.notifywrite
         node.initialread = config.initialread || false
-
+        node.listenallga = config.listenallga || false
+        
         node.on("input", function (msg) {
-            if (node.server && node.topic) {
-                node.server.readValue(node.topic)
+            if (!node.listenallga) {
+                if (node.server && node.topic) {
+                    node.server.readValue(node.topic)
+                }
+            } else {
+                if (node.server) {
+                    for (let index = 0; index < node.server.csv.length; index++) {
+                        const element = node.server.csv[index];
+                        node.server.readValue(element.ga)
+                    }
+                }
             }
+            
         })
 
         node.on('close', function () {
@@ -23,7 +34,7 @@ module.exports = function (RED) {
         })
 
         if (node.server) {
-            if (node.topic) {
+            if (node.topic || node.listenallga ) {
                 node.server.register("in", node)
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "node-red-contrib-knx-easy",
+  "version": "0.3.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "6.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.7.tgz",
+      "integrity": "sha512-YbPXbaynBTe0pVExPhL76TsWnxSPeFAvImIsmylpBWn/yfw+lHy+Q68aawvZHsgskT44ZAoeE67GM5f+Brekew=="
+    },
+    "binary-parser": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/binary-parser/-/binary-parser-1.1.5.tgz",
+      "integrity": "sha1-ciTWGk4vp7Wu3mn+Tw6moJAreeg="
+    },
+    "binary-protocol": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/binary-protocol/-/binary-protocol-0.0.0.tgz",
+      "integrity": "sha1-ZU4tbCB8HS7qpl1dais+ulmu024=",
+      "requires": {
+        "bluebird": "2.2.2"
+      }
+    },
+    "bluebird": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz",
+      "integrity": "sha1-8b8Fq8iHz5pwOIYjfChhCkOx8RQ="
+    },
+    "ipaddr.js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
+      "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q="
+    },
+    "knx": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/knx/-/knx-2.3.3.tgz",
+      "integrity": "sha512-Oeb9rFIq1dUt7oa4V6eARnzvS7RtCFKGhM07Ro1W/vTfLUzJswsIoj7yzEVpMHAt2FmkDn5BMOvtc37u3d2dtw==",
+      "requires": {
+        "@types/node": "6.14.7",
+        "binary-parser": "1.1.5",
+        "binary-protocol": "0.0.0",
+        "ipaddr.js": "1.2.0",
+        "log-driver": "1.2.7",
+        "machina": "4.0.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
+    },
+    "machina": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/machina/-/machina-4.0.2.tgz",
+      "integrity": "sha512-OOlFrW1rd783S6tF36v5Ie/TM64gfvSl9kYLWL2cPA31J71HHWW3XrgSe1BZSFAPkh8532CMJMLv/s9L2aopiA==",
+      "requires": {
+        "lodash": "4.17.15"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hello atlewee,
i've been implemented the possibility to copy/paste the CVS of the group addresses, created by ETS.
Thank to this, you can use the KnxEasy-in as an universal group address input, that can handle all group addresses of the CSV, by outputting the correct decoded payload as well as the device name (ex: "kitchen lamp").
The KnxEasy-in Node has a new checkbox "listen to all group addresses".
Added node's status for each node as well, with group address and value.
Modified the default config's node host address from "localhost" to standard "224.0.23.12"
See https://github.com/atlewee/node-red-contrib-knx-easy/issues/20